### PR TITLE
Preserve const qualifier from pointer target type

### DIFF
--- a/main.c
+++ b/main.c
@@ -32,7 +32,7 @@ void print_stats()
     fflush(stdout);
 }
 
-void print_change(int id, char name[], char action[])
+void print_change(int id, const char name[], const char action[])
 {
     printf("%s %-2d %s\n", name, id, action);
     fflush(stdout);


### PR DESCRIPTION
This fixes most compilation warnings related to passing `const char[]` to a function that accepts `char[]` type of variable.

I tested my changes and can confirm they introduce no regressions :+1: 

Example snippet of these logs
```
main.c: In function ‘ns_start_reading’:
main.c:312:22: warning: passing argument 2 of ‘print_change’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
  312 |     print_change(id, READER_NAME, ARRIVAL_NAME);
      |                      ^~~~~~~~~~~
main.c:35:32: note: expected ‘char *’ but argument is of type ‘const char *’
   35 | void print_change(int id, char name[], char action[])
      |                           ~~~~~^~~~~~
main.c:312:35: warning: passing argument 3 of ‘print_change’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
  312 |     print_change(id, READER_NAME, ARRIVAL_NAME);
      |                                   ^~~~~~~~~~~~
main.c:35:45: note: expected ‘char *’ but argument is of type ‘const char *’
   35 | void print_change(int id, char name[], char action[])
      |                                        ~~~~~^~~~~~~~
```
